### PR TITLE
Regex should be case insensitive 

### DIFF
--- a/Explore UniProtKB with Amazon Neptune.ipynb
+++ b/Explore UniProtKB with Amazon Neptune.ipynb
@@ -367,7 +367,7 @@
     "        rdfs:label ?label .\n",
     "    \n",
     "    BIND(STRAFTER(STR(?go), \"obo/\") AS ?goCode)\n",
-    "    FILTER (REGEX(STR(?label), \"^*cholesterol biosynthetic*\"))\n",
+    "    FILTER (REGEX(?label, \"^cholesterol biosynthetic\", \"i\"))\n",
     "}\n",
     "ORDER BY ?proteinMnemonic ?go\n",
     "LIMIT 50"
@@ -408,7 +408,7 @@
     "    \n",
     "    BIND(STRAFTER(STR(?go), \"obo/\") AS ?goCode)\n",
     "    BIND(STRAFTER(STR(?ancestorGo), \"obo/\") AS ?ancestorGoCode)\n",
-    "    FILTER (REGEX(STR(?label), \"^*cholesterol biosynthetic*\"))\n",
+    "    FILTER (REGEX(?label, \"^cholesterol biosynthetic\", \"i\"))\n",
     "    \n",
     "    MINUS {\n",
     "       ?protein up:classifiedWith ?ancestorGo .\n",
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Regex is not quite standard as it was used, as this will be reused by lot's of people the regex should be put in case insensitive mode.

Only kept the anchor to show it is a regex. Label is already a String so should not be cast.

The query as it is would have been faster with [`contains`](https://www.w3.org/TR/sparql11-query/#func-contains)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
